### PR TITLE
EKF-GSF: Trigger heading reset faster on takeoff

### DIFF
--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -19,7 +19,7 @@
 #include <mathlib/mathlib.h>
 #include <cstdlib>
 
-void Ekf::quatPredictEKFGSF(uint8_t model_index)
+void Ekf::quatPredictEKFGSF(const uint8_t model_index)
 {
 	// generate attitude solution using simple complementary filter for the selected model
 
@@ -27,7 +27,7 @@ void Ekf::quatPredictEKFGSF(uint8_t model_index)
 	// Project 'k' unit vector of earth frame to body frame
 	// Vector3f k = quaterion.conjugate_inversed(Vector3f(0.0f, 0.0f, 1.0f));
 	// Optimized version with dropped zeros
-	Vector3f k(
+	const Vector3f k(
 		2.0f * (_ahrs_ekf_gsf[model_index].quat(1) * _ahrs_ekf_gsf[model_index].quat(3) - _ahrs_ekf_gsf[model_index].quat(0) * _ahrs_ekf_gsf[model_index].quat(2)),
 		2.0f * (_ahrs_ekf_gsf[model_index].quat(2) * _ahrs_ekf_gsf[model_index].quat(3) + _ahrs_ekf_gsf[model_index].quat(0) * _ahrs_ekf_gsf[model_index].quat(1)),
 		(_ahrs_ekf_gsf[model_index].quat(0) * _ahrs_ekf_gsf[model_index].quat(0) - _ahrs_ekf_gsf[model_index].quat(1) * _ahrs_ekf_gsf[model_index].quat(1) - _ahrs_ekf_gsf[model_index].quat(2) * _ahrs_ekf_gsf[model_index].quat(2) + _ahrs_ekf_gsf[model_index].quat(3) * _ahrs_ekf_gsf[model_index].quat(3))
@@ -40,7 +40,7 @@ void Ekf::quatPredictEKFGSF(uint8_t model_index)
 	if (_ahrs_accel_norm > 0.5f * CONSTANTS_ONE_G && (_ahrs_accel_norm < 1.5f * CONSTANTS_ONE_G || _ahrs_turn_comp_enabled)) {
 		if (_ahrs_turn_comp_enabled) {
 			// turn rate is component of gyro rate about vertical (down) axis
-			float turn_rate = _ahrs_ekf_gsf[model_index].R(2,0) * _ang_rate_delayed_raw(0)
+			const float turn_rate = _ahrs_ekf_gsf[model_index].R(2,0) * _ang_rate_delayed_raw(0)
 					  + _ahrs_ekf_gsf[model_index].R(2,1) * _ang_rate_delayed_raw(1)
 					  + _ahrs_ekf_gsf[model_index].R(2,2) * _ang_rate_delayed_raw(2);
 
@@ -76,7 +76,7 @@ void Ekf::quatPredictEKFGSF(uint8_t model_index)
 
 	// Gyro bias estimation
 	const float gyro_bias_limit = 0.05f;
-	float spinRate = _ang_rate_delayed_raw.length();
+	const float spinRate = _ang_rate_delayed_raw.length();
 	if (spinRate < 0.175f) {
 		_ahrs_ekf_gsf[model_index].gyro_bias -= correction * (_params.EKFGSF_gyro_bias_gain * _imu_sample_delayed.delta_ang_dt);
 
@@ -85,7 +85,7 @@ void Ekf::quatPredictEKFGSF(uint8_t model_index)
 		}
 	}
 
-	Vector3f rates = _ang_rate_delayed_raw - _ahrs_ekf_gsf[model_index].gyro_bias;
+	const Vector3f rates = _ang_rate_delayed_raw - _ahrs_ekf_gsf[model_index].gyro_bias;
 
 	// Feed forward gyro
 	correction += rates;
@@ -114,13 +114,13 @@ void Ekf::alignQuatEKFGSF()
 
 	// Calculate earth frame North axis unit vector rotated into body frame, orthogonal to 'down_in_bf'
 	// * operator is overloaded to provide a dot product
-	Vector3f i_vec_bf(1.0f,0.0f,0.0f);
+	const Vector3f i_vec_bf(1.0f,0.0f,0.0f);
 	Vector3f north_in_bf = i_vec_bf - down_in_bf * (i_vec_bf * down_in_bf);
 	north_in_bf.normalize();
 
 	// Calculate earth frame East axis unit vector rotated into body frame, orthogonal to 'down_in_bf' and 'north_in_bf'
 	// % operator is overloaded to provide a cross product
-	Vector3f east_in_bf = down_in_bf % north_in_bf;
+	const Vector3f east_in_bf = down_in_bf % north_in_bf;
 
 	// Each column in a rotation matrix from earth frame to body frame represents the projection of the
 	// corresponding earth frame unit vector rotated into the body frame, eg 'north_in_bf' would be the first column.
@@ -173,7 +173,7 @@ void Ekf::alignQuatYawEKFGSF()
 }
 
 // predict states and covariance for specified model index
-void Ekf::statePredictEKFGSF(uint8_t model_index)
+void Ekf::statePredictEKFGSF(const uint8_t model_index)
 {
 	// generate an attitude reference using IMU data
 	quatPredictEKFGSF(model_index);
@@ -195,9 +195,9 @@ void Ekf::statePredictEKFGSF(uint8_t model_index)
 	}
 
 	// calculate delta velocity in a horizontal front-right frame
-	Vector3f del_vel_NED = _ahrs_ekf_gsf[model_index].R * _imu_sample_delayed.delta_vel;
-	float dvx =   del_vel_NED(0) * cosf(_ekf_gsf[model_index].X[2]) + del_vel_NED(1) * sinf(_ekf_gsf[model_index].X[2]);
-	float dvy = - del_vel_NED(0) * sinf(_ekf_gsf[model_index].X[2]) + del_vel_NED(1) * cosf(_ekf_gsf[model_index].X[2]);
+	const Vector3f del_vel_NED = _ahrs_ekf_gsf[model_index].R * _imu_sample_delayed.delta_vel;
+	const float dvx =   del_vel_NED(0) * cosf(_ekf_gsf[model_index].X[2]) + del_vel_NED(1) * sinf(_ekf_gsf[model_index].X[2]);
+	const float dvy = - del_vel_NED(0) * sinf(_ekf_gsf[model_index].X[2]) + del_vel_NED(1) * cosf(_ekf_gsf[model_index].X[2]);
 
 	// sum delta velocities in earth frame:
 	_ekf_gsf[model_index].X[0] += del_vel_NED(0);
@@ -222,21 +222,21 @@ void Ekf::statePredictEKFGSF(uint8_t model_index)
 	const float dvyVar = dvxVar; // variance of right delta velocity - (m/s)^2
 	const float dazVar = sq(_params.EKFGSF_gyro_noise * _imu_sample_delayed.delta_ang_dt); // variance of yaw delta angle - rad^2
 
-	float t2 = sinf(_ekf_gsf[model_index].X[2]);
-	float t3 = cosf(_ekf_gsf[model_index].X[2]);
-	float t4 = dvy*t3;
-	float t5 = dvx*t2;
-	float t6 = t4+t5;
-	float t8 = P22*t6;
-	float t7 = P02-t8;
-	float t9 = dvx*t3;
-	float t11 = dvy*t2;
-	float t10 = t9-t11;
-	float t12 = dvxVar*t2*t3;
-	float t13 = t2*t2;
-	float t14 = t3*t3;
-	float t15 = P22*t10;
-	float t16 = P12+t15;
+	const float t2 = sinf(_ekf_gsf[model_index].X[2]);
+	const float t3 = cosf(_ekf_gsf[model_index].X[2]);
+	const float t4 = dvy*t3;
+	const float t5 = dvx*t2;
+	const float t6 = t4+t5;
+	const float t8 = P22*t6;
+	const float t7 = P02-t8;
+	const float t9 = dvx*t3;
+	const float t11 = dvy*t2;
+	const float t10 = t9-t11;
+	const float t12 = dvxVar*t2*t3;
+	const float t13 = t2*t2;
+	const float t14 = t3*t3;
+	const float t15 = P22*t10;
+	const float t16 = P12+t15;
 
 	const float min_var = 1e-6f;
 	_ekf_gsf[model_index].P[0][0] = fmaxf(P00-P20*t6+dvxVar*t14+dvyVar*t13-t6*t7 , min_var);
@@ -254,25 +254,25 @@ void Ekf::statePredictEKFGSF(uint8_t model_index)
 }
 
 // Update EKF states and covariance for specified model index using velocity measurement
-void Ekf::stateUpdateEKFGSF(uint8_t model_index)
+void Ekf::stateUpdateEKFGSF(const uint8_t model_index)
 {
 	// set observation variance from accuracy estimate supplied by GPS and apply a sanity check minimum
-	float velObsVar = sq(fmaxf(_gps_sample_delayed.sacc, _params.gps_vel_noise));
+	const float velObsVar = sq(fmaxf(_gps_sample_delayed.sacc, _params.gps_vel_noise));
 
 	// calculate velocity observation innovations
 	_ekf_gsf[model_index].innov[0] = _ekf_gsf[model_index].X[0] - _gps_sample_delayed.vel(0);
 	_ekf_gsf[model_index].innov[1] = _ekf_gsf[model_index].X[1] - _gps_sample_delayed.vel(1);
 
 	// copy covariance matrix to temporary variables
-	float P00 = _ekf_gsf[model_index].P[0][0];
-	float P01 = _ekf_gsf[model_index].P[0][1];
-	float P02 = _ekf_gsf[model_index].P[0][2];
-	float P10 = _ekf_gsf[model_index].P[1][0];
-	float P11 = _ekf_gsf[model_index].P[1][1];
-	float P12 = _ekf_gsf[model_index].P[1][2];
-	float P20 = _ekf_gsf[model_index].P[2][0];
-	float P21 = _ekf_gsf[model_index].P[2][1];
-	float P22 = _ekf_gsf[model_index].P[2][2];
+	const float P00 = _ekf_gsf[model_index].P[0][0];
+	const float P01 = _ekf_gsf[model_index].P[0][1];
+	const float P02 = _ekf_gsf[model_index].P[0][2];
+	const float P10 = _ekf_gsf[model_index].P[1][0];
+	const float P11 = _ekf_gsf[model_index].P[1][1];
+	const float P12 = _ekf_gsf[model_index].P[1][2];
+	const float P20 = _ekf_gsf[model_index].P[2][0];
+	const float P21 = _ekf_gsf[model_index].P[2][1];
+	const float P22 = _ekf_gsf[model_index].P[2][2];
 
 	// calculate innovation variance
 	_ekf_gsf[model_index].S[0][0] = P00 + velObsVar;
@@ -286,12 +286,12 @@ void Ekf::stateUpdateEKFGSF(uint8_t model_index)
 	if (fabsf(S_det_inv) > 1E-6f) {
 		// Calculate elements for innovation covariance inverse matrix assuming symmetry
 		S_det_inv = 1.0f / S_det_inv;
-		float S_inv_NN = _ekf_gsf[model_index].S[1][1] * S_det_inv;
-		float S_inv_EE = _ekf_gsf[model_index].S[0][0] * S_det_inv;
-		float S_inv_NE = _ekf_gsf[model_index].S[0][1] * S_det_inv;
+		const float S_inv_NN = _ekf_gsf[model_index].S[1][1] * S_det_inv;
+		const float S_inv_EE = _ekf_gsf[model_index].S[0][0] * S_det_inv;
+		const float S_inv_NE = _ekf_gsf[model_index].S[0][1] * S_det_inv;
 
 		// The following expression was derived symbolically from test ratio = transpose(innovation) * inverse(innovation variance) * innovation = [1x2] * [2,2] * [2,1] = [1,1]
-		float test_ratio = _ekf_gsf[model_index].innov[0]*(_ekf_gsf[model_index].innov[0]*S_inv_NN + _ekf_gsf[model_index].innov[1]*S_inv_NE) + _ekf_gsf[model_index].innov[1]*(_ekf_gsf[model_index].innov[0]*S_inv_NE + _ekf_gsf[model_index].innov[1]*S_inv_EE);
+		const float test_ratio = _ekf_gsf[model_index].innov[0]*(_ekf_gsf[model_index].innov[0]*S_inv_NN + _ekf_gsf[model_index].innov[1]*S_inv_NE) + _ekf_gsf[model_index].innov[1]*(_ekf_gsf[model_index].innov[0]*S_inv_NE + _ekf_gsf[model_index].innov[1]*S_inv_EE);
 
 		// If the test ratio is greater than 25 (5 Sigma) then reduce the length of the innovation vector to clip it at 5-Sigma
 		// This protects from large measurement spikes
@@ -306,12 +306,12 @@ void Ekf::stateUpdateEKFGSF(uint8_t model_index)
 	// calculate Kalman gain K  and covariance matrix P
 	// autocode from https://github.com/priseborough/3_state_filter/blob/flightLogReplay-wip/calcK.txt
 	// and https://github.com/priseborough/3_state_filter/blob/flightLogReplay-wip/calcPmat.txt
-	float t2 = P00*velObsVar;
- 	float t3 = P11*velObsVar;
-	float t4 = velObsVar*velObsVar;
-	float t5 = P00*P11;
-	float t9 = P01*P10;
-	float t6 = t2+t3+t4+t5-t9;
+	const float t2 = P00*velObsVar;
+ 	const float t3 = P11*velObsVar;
+	const float t4 = velObsVar*velObsVar;
+	const float t5 = P00*P11;
+	const float t9 = P01*P10;
+	const float t6 = t2+t3+t4+t5-t9;
 	float t7;
 	if (fabsf(t6) > 1e-6f) {
 		t7 = 1.0f/t6;
@@ -319,8 +319,8 @@ void Ekf::stateUpdateEKFGSF(uint8_t model_index)
 		// skip this fusion step
 		return;
 	}
-	float t8 = P11+velObsVar;
-	float t10 = P00+velObsVar;
+	const float t8 = P11+velObsVar;
+	const float t10 = P00+velObsVar;
 	float K[3][2];
 
  	K[0][0] = -P01*P10*t7+P00*t7*t8;
@@ -330,41 +330,41 @@ void Ekf::stateUpdateEKFGSF(uint8_t model_index)
 	K[2][0] = -P10*P21*t7+P20*t7*t8;
 	K[2][1] = -P01*P20*t7+P21*t7*t10;
 
-	float t11 = P00*P01*t7;
-	float t15 = P01*t7*t10;
-	float t12 = t11-t15;
-	float t13 = P01*P10*t7;
-	float t16 = P00*t7*t8;
-	float t14 = t13-t16;
-	float t17 = t8*t12;
-	float t18 = P01*t14;
-	float t19 = t17+t18;
-	float t20 = t10*t14;
-	float t21 = P10*t12;
-	float t22 = t20+t21;
-	float t27 = P11*t7*t10;
-	float t23 = t13-t27;
-	float t24 = P10*P11*t7;
-	float t26 = P10*t7*t8;
-	float t25 = t24-t26;
-	float t28 = t8*t23;
-	float t29 = P01*t25;
-	float t30 = t28+t29;
-	float t31 = t10*t25;
-	float t32 = P10*t23;
-	float t33 = t31+t32;
-	float t34 = P01*P20*t7;
-	float t38 = P21*t7*t10;
-	float t35 = t34-t38;
-	float t36 = P10*P21*t7;
-	float t39 = P20*t7*t8;
-	float t37 = t36-t39;
-	float t40 = t8*t35;
-	float t41 = P01*t37;
-	float t42 = t40+t41;
-	float t43 = t10*t37;
-	float t44 = P10*t35;
-	float t45 = t43+t44;
+	const float t11 = P00*P01*t7;
+	const float t15 = P01*t7*t10;
+	const float t12 = t11-t15;
+	const float t13 = P01*P10*t7;
+	const float t16 = P00*t7*t8;
+	const float t14 = t13-t16;
+	const float t17 = t8*t12;
+	const float t18 = P01*t14;
+	const float t19 = t17+t18;
+	const float t20 = t10*t14;
+	const float t21 = P10*t12;
+	const float t22 = t20+t21;
+	const float t27 = P11*t7*t10;
+	const float t23 = t13-t27;
+	const float t24 = P10*P11*t7;
+	const float t26 = P10*t7*t8;
+	const float t25 = t24-t26;
+	const float t28 = t8*t23;
+	const float t29 = P01*t25;
+	const float t30 = t28+t29;
+	const float t31 = t10*t25;
+	const float t32 = P10*t23;
+	const float t33 = t31+t32;
+	const float t34 = P01*P20*t7;
+	const float t38 = P21*t7*t10;
+	const float t35 = t34-t38;
+	const float t36 = P10*P21*t7;
+	const float t39 = P20*t7*t8;
+	const float t37 = t36-t39;
+	const float t40 = t8*t35;
+	const float t41 = P01*t37;
+	const float t42 = t40+t41;
+	const float t43 = t10*t37;
+	const float t44 = P10*t35;
+	const float t45 = t43+t44;
 
 	const float min_var = 1e-6f;
 	_ekf_gsf[model_index].P[0][0] = fmaxf(P00-t12*t19-t14*t22 , min_var);
@@ -402,7 +402,7 @@ void Ekf::stateUpdateEKFGSF(uint8_t model_index)
 		rot312(2) = atan2f(-_ahrs_ekf_gsf[model_index].R(2, 0), _ahrs_ekf_gsf[model_index].R(2, 2));  // third rotation is about Y and is taken from AHRS
 
 		// Calculate the body to earth frame rotation matrix
-		Dcmf R = taitBryan312ToRotMat(rot312);
+		const Dcmf R = taitBryan312ToRotMat(rot312);
 
 		// update the quaternion used by the AHRS prediction algorithm
 		_ahrs_ekf_gsf[model_index].quat = Quatf(R);
@@ -457,7 +457,7 @@ void Ekf::runEKFGSF()
 		const float accel_norm_sq = _ahrs_accel.norm_squared();
 		const float upper_accel_limit = CONSTANTS_ONE_G * 1.1f;
 		const float lower_accel_limit = CONSTANTS_ONE_G * 0.9f;
-		bool ok_to_align = ((accel_norm_sq > lower_accel_limit * lower_accel_limit &&
+		const bool ok_to_align = ((accel_norm_sq > lower_accel_limit * lower_accel_limit &&
 			  accel_norm_sq < upper_accel_limit * upper_accel_limit));
 		if (ok_to_align) {
 			initialiseEKFGSF();
@@ -533,7 +533,7 @@ void Ekf::runEKFGSF()
 			}
 
 			// rescale the unmodified weights to make the total sum unity
-			float scale_factor = (unmodified_weights_sum - correction_sum - _params.EKFGSF_weight_min) / (unmodified_weights_sum - _params.EKFGSF_weight_min);
+			const float scale_factor = (unmodified_weights_sum - correction_sum - _params.EKFGSF_weight_min) / (unmodified_weights_sum - _params.EKFGSF_weight_min);
 			for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
 				if (!change_mask[model_index]) {
 					_ekf_gsf[model_index].W = _params.EKFGSF_weight_min + scale_factor * (_ekf_gsf[model_index].W - _params.EKFGSF_weight_min);
@@ -571,11 +571,11 @@ void Ekf::runEKFGSF()
 	*/
 }
 
-float Ekf::gaussianDensityEKFGSF(uint8_t model_index)
+float Ekf::gaussianDensityEKFGSF(const uint8_t model_index) const
 {
-	float t2 = _ekf_gsf[model_index].S[0][0] * _ekf_gsf[model_index].S[1][1];
-	float t5 = _ekf_gsf[model_index].S[0][1] * _ekf_gsf[model_index].S[1][0];
-	float t3 = t2 - t5; // determinant
+	const float t2 = _ekf_gsf[model_index].S[0][0] * _ekf_gsf[model_index].S[1][1];
+	const float t5 = _ekf_gsf[model_index].S[0][1] * _ekf_gsf[model_index].S[1][0];
+	const float t3 = t2 - t5; // determinant
 	float t4; // determinant inverse
 	if (fabsf(t3) > 1e-6f) {
 		t4 = 1.0f/t3;
@@ -603,7 +603,7 @@ float Ekf::gaussianDensityEKFGSF(uint8_t model_index)
 	return normDist;
 }
 
-void Ekf::getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF])
+void Ekf::getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) const
 {
 	memcpy(yaw_composite, &X_GSF[2], sizeof(X_GSF[2]));
 	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index++) {
@@ -614,7 +614,7 @@ void Ekf::getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float 
 	}
 }
 
-void Ekf::makeCovSymEKFGSF(uint8_t model_index)
+void Ekf::makeCovSymEKFGSF(const uint8_t model_index)
 {
 	float P01 = 0.5f * (_ekf_gsf[model_index].P[0][1] + _ekf_gsf[model_index].P[1][0]);
 	float P02 = 0.5f * (_ekf_gsf[model_index].P[0][2] + _ekf_gsf[model_index].P[2][0]);
@@ -653,7 +653,7 @@ void Ekf::resetYawToEKFGSF()
 		rot312(2) = atan2f(-_R_to_earth(2, 0), _R_to_earth(2, 2));  // third rotation about Y is taken from main EKF
 
 		// Calculate the body to earth frame rotation matrix
-		Dcmf R = taitBryan312ToRotMat(rot312);
+		const Dcmf R = taitBryan312ToRotMat(rot312);
 
 		// calculate initial quaternion states for the main EKF
 		// we don't change the output attitude to avoid jumps
@@ -721,7 +721,7 @@ bool Ekf::get_algo_test_data(float delAng[3],
 		bool *fuse_vel,
 		float quat[4])
 {
-	bool vel_updated = _control_status.flags.gps && _gps_data_ready;
+	const bool vel_updated = _control_status.flags.gps && _gps_data_ready;
 
 	delAng[0] = _imu_sample_delayed.delta_ang(0);
 	delAng[1] = _imu_sample_delayed.delta_ang(1);
@@ -770,12 +770,12 @@ void Ekf::request_ekfgsf_yaw_reset(uint8_t counter)
 Dcmf Ekf::taitBryan312ToRotMat(Vector3f &rot312)
 {
 		// Calculate the frame2 to frame 1 rotation matrix from a 312 rotation sequence
-		float c2 = cosf(rot312(2));
-		float s2 = sinf(rot312(2));
-		float s1 = sinf(rot312(1));
-		float c1 = cosf(rot312(1));
-		float s0 = sinf(rot312(0));
-		float c0 = cosf(rot312(0));
+		const float c2 = cosf(rot312(2));
+		const float s2 = sinf(rot312(2));
+		const float s1 = sinf(rot312(1));
+		const float c1 = cosf(rot312(1));
+		const float s0 = sinf(rot312(0));
+		const float c0 = cosf(rot312(0));
 
 		Dcmf R;
 		R(0, 0) = c0 * c2 - s0 * s1 * s2;

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -44,7 +44,7 @@ void Ekf::quatPredictEKFGSF(uint8_t model_index)
 					  + _ahrs_ekf_gsf[model_index].R(2,1) * _ang_rate_delayed_raw(1)
 					  + _ahrs_ekf_gsf[model_index].R(2,2) * _ang_rate_delayed_raw(2);
 
-			// use measured airspeed to calculate centripetal acceeration if available
+			// use measured airspeed to calculate centripetal acceleration if available
 			float centripetal_accel;
 			if (_imu_sample_delayed.time_us - _airspeed_sample_delayed.time_us < 1000000) {
 				centripetal_accel = _airspeed_sample_delayed.true_airspeed * turn_rate;
@@ -53,7 +53,7 @@ void Ekf::quatPredictEKFGSF(uint8_t model_index)
 			}
 
 			// project Y body axis onto horizontal and multiply by centripetal acceleration to give estimated
-			// centrietal acceleratoin vector in earth frame due to coordinated turn
+			// centripetal acceleration vector in earth frame due to coordinated turn
 			Vector3f centripetal_accel_vec_ef = {_ahrs_ekf_gsf[model_index].R(0,1), _ahrs_ekf_gsf[model_index].R(1,1), 0.0f};
 			if (_ahrs_ekf_gsf[model_index].R(2,2) > 0.0f) {
 				// vehicle is upright
@@ -96,7 +96,7 @@ void Ekf::quatPredictEKFGSF(uint8_t model_index)
 	// Normalize quaternion
 	_ahrs_ekf_gsf[model_index].quat.normalize();
 
-	// uodate body to earth frame rotation matrix
+	// update body to earth frame rotation matrix
 	_ahrs_ekf_gsf[model_index].R = quat_to_invrotmat(_ahrs_ekf_gsf[model_index].quat);
 
 }
@@ -108,7 +108,7 @@ void Ekf::alignQuatEKFGSF()
 	// 1) Yaw angle is zero - yaw is aligned later for each model when velocity fusion commences.
 	// 2) The vehicle is not accelerating so all of the measured acceleration is due to gravity.
 
-	// Calcuate earth frame Down axis unit vector rotated into body frame
+	// Calculate earth frame Down axis unit vector rotated into body frame
 	Vector3f down_in_bf = -_imu_sample_delayed.delta_vel;
 	down_in_bf.normalize();
 
@@ -199,7 +199,7 @@ void Ekf::statePredictEKFGSF(uint8_t model_index)
 	float dvx =   del_vel_NED(0) * cosf(_ekf_gsf[model_index].X[2]) + del_vel_NED(1) * sinf(_ekf_gsf[model_index].X[2]);
 	float dvy = - del_vel_NED(0) * sinf(_ekf_gsf[model_index].X[2]) + del_vel_NED(1) * cosf(_ekf_gsf[model_index].X[2]);
 
-	// sum delta velocties in earth frame:
+	// sum delta velocities in earth frame:
 	_ekf_gsf[model_index].X[0] += del_vel_NED(0);
 	_ekf_gsf[model_index].X[1] += del_vel_NED(1);
 
@@ -256,7 +256,7 @@ void Ekf::statePredictEKFGSF(uint8_t model_index)
 // Update EKF states and covariance for specified model index using velocity measurement
 void Ekf::stateUpdateEKFGSF(uint8_t model_index)
 {
-	// set observation variance from accuracy estiate supplied by GPS and apply a sanity check minimum
+	// set observation variance from accuracy estimate supplied by GPS and apply a sanity check minimum
 	float velObsVar = sq(fmaxf(_gps_sample_delayed.sacc, _params.gps_vel_noise));
 
 	// calculate velocity observation innovations
@@ -280,11 +280,11 @@ void Ekf::stateUpdateEKFGSF(uint8_t model_index)
 	_ekf_gsf[model_index].S[0][1] = P01;
 	_ekf_gsf[model_index].S[1][0] = P10;
 
-	// Perform a chi-square innovaton consistency test and calculate a compression scale factor that limits the magnitude of innovations to 5-sigma
+	// Perform a chi-square innovation consistency test and calculate a compression scale factor that limits the magnitude of innovations to 5-sigma
 	float S_det_inv = (_ekf_gsf[model_index].S[0][0]*_ekf_gsf[model_index].S[1][1] - _ekf_gsf[model_index].S[0][1]*_ekf_gsf[model_index].S[1][0]);
 	float innov_comp_scale_factor = 1.0f;
 	if (fabsf(S_det_inv) > 1E-6f) {
-		// Calculate elements for innvoation covariance inverse matrix assuming symmetry
+		// Calculate elements for innovation covariance inverse matrix assuming symmetry
 		S_det_inv = 1.0f / S_det_inv;
 		float S_inv_NN = _ekf_gsf[model_index].S[1][1] * S_det_inv;
 		float S_inv_EE = _ekf_gsf[model_index].S[0][0] * S_det_inv;
@@ -429,7 +429,7 @@ void Ekf::initialiseEKFGSF()
 		// evenly space initial yaw estimates in the region between +-Pi
 		_ekf_gsf[model_index].X[2] = -M_PI_F + (0.5f * yaw_increment) + ((float)model_index * yaw_increment);
 
-		// All filter modesl start with the same weight
+		// All filter models start with the same weight
 		_ekf_gsf[model_index].W = 1.0f / (float)N_MODELS_EKFGSF;
 
 		// Assume velocity within 0.5 m/s of zero at alignment
@@ -490,7 +490,7 @@ void Ekf::runEKFGSF()
 	if (_control_status.flags.gps && _gps_data_ready && _control_status.flags.in_air) {
 		if (!_ekf_gsf_vel_fuse_started) {
 			for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
-				// use the first measurement to set the velocities and correspnding covariances
+				// use the first measurement to set the velocities and corresponding covariances
 				_ekf_gsf[model_index].X[0] = _gps_sample_delayed.vel(0);
 				_ekf_gsf[model_index].X[1] = _gps_sample_delayed.vel(1);
 				_ekf_gsf[model_index].P[0][0] = sq(_gps_sample_delayed.sacc);
@@ -502,7 +502,7 @@ void Ekf::runEKFGSF()
 			float total_w = 0.0f;
 			float newWeight[N_MODELS_EKFGSF];
 			for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
-				// subsequent measuremnents are fused as direct state observations
+				// subsequent measurements are fused as direct state observations
 				stateUpdateEKFGSF(model_index);
 
 				// calculate weighting for each model assuming a normal distribution
@@ -555,7 +555,7 @@ void Ekf::runEKFGSF()
 	}
 	/*
 	// calculate a composite covariance matrix from a weighted average of the covariance for each model
-	// models with larger innvoations are weighted less
+	// models with larger innovations are weighted less
 	memset(&P_GSF, 0, sizeof(P_GSF));
 	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
 		float Xdelta[3];
@@ -682,7 +682,7 @@ void Ekf::resetYawToEKFGSF()
 		resetExtVisRotMat();
 	}
 
-	// update the yaw angle variance using half the nominal yaw separation ebtween models
+	// update the yaw angle variance using half the nominal yaw separation between models
 	increaseQuatYawErrVariance(sq(fmaxf(M_PI_F / (float)N_MODELS_EKFGSF, 1.0e-2f)));
 
 	// add the reset amount to the output observer buffered data
@@ -752,7 +752,7 @@ bool Ekf::get_algo_test_data(float delAng[3],
 }
 
 // request the EKF reset the yaw to the estimate from the internal EKF-GSF filter
-// argment should be incremented only when a new reset is required
+// argument should be incremented only when a new reset is required
 void Ekf::request_ekfgsf_yaw_reset(uint8_t counter)
 {
 	if (counter > _yaw_extreset_counter) {

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -367,7 +367,7 @@ struct parameters {
 	float EKFGSF_gyro_bias_gain{0.04f};	///< gain applied to integral of gyro correction for complementary filter (1/sec)
 	float EKFGSF_weight_min{0.0f};		///< minimum value of an individual model weighting
 	float EKFGSF_tas_default{15.0f};	///< default airspeed value assumed during fixed wing flight if no airspeed measurement available (m/s)
-	unsigned EKFGSF_reset_delay{2000000};	///< Number of uSec of bad innovations on main filter inpost takeoff phase before yaw is reset to EKF-GSF value
+	unsigned EKFGSF_reset_delay{1000000};	///< Number of uSec of bad innovations on main filter inpost takeoff phase before yaw is reset to EKF-GSF value
 };
 
 struct stateSample {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -663,27 +663,24 @@ void Ekf::controlGpsFusion()
 
 		// handle the case when we now have GPS, but have not been using it for an extended period
 		if (_control_status.flags.gps) {
-			// Handle divergence shortly after takeoff casued by a bad yaw angle. Be faster to reset yaw
-			// in this period because bad yaw induced large GPS innovations will manifest soon after takeoff.
-			const bool recent_takeoff = (_control_status.flags.in_air && (_imu_sample_delayed.time_us - _time_last_on_ground_us) < 30000000);
-			unsigned timeout_limit_us = (recent_takeoff ? _params.EKFGSF_reset_delay : _params.reset_timeout_max);
-
 			// We are relying on aiding to constrain drift so after a specified time
 			// with no aiding we need to do something
-			bool do_reset = ((_time_last_imu - _time_last_pos_fuse) > timeout_limit_us)
-					&& ((_time_last_imu - _time_last_delpos_fuse) > timeout_limit_us)
-					&& ((_time_last_imu - _time_last_vel_fuse) > timeout_limit_us)
-					&& ((_time_last_imu - _time_last_of_fuse) > timeout_limit_us);
+			bool do_reset = ((_time_last_imu - _time_last_pos_fuse) > _params.reset_timeout_max)
+					&& ((_time_last_imu - _time_last_delpos_fuse) > _params.reset_timeout_max)
+					&& ((_time_last_imu - _time_last_vel_fuse) > _params.reset_timeout_max)
+					&& ((_time_last_imu - _time_last_of_fuse) > _params.reset_timeout_max);
 
 			// We haven't had an absolute position fix for a longer time so need to do something
-			do_reset = do_reset || ((_time_last_imu - _time_last_pos_fuse) > (2 * timeout_limit_us));
+			do_reset = do_reset || ((_time_last_imu - _time_last_pos_fuse) > (2 * _params.reset_timeout_max));
 
 			// A reset to the EKF-GSF estimate can be performed after a recent takeoff which will enable
-			// recovery from a bad magnetomer or field estimate.
+			// recovery from a bad magnetometer or field estimate.
 			// This special case reset can also be requested externally.
 			// The minimum time interval between resets to the EKF-GSF estimate must be limited to
 			// allow the EKF-GSF time to improve its estimate if the first reset was not successful.
-			bool reset_yaw_to_EKFGSF = (do_reset || _do_emergency_yaw_reset) && recent_takeoff && ((_imu_sample_delayed.time_us - _emergency_yaw_reset_time) > 5000000);
+			do_reset = do_reset || (_time_last_imu - _time_last_vel_fuse) > _params.EKFGSF_reset_delay;
+			const bool recent_takeoff = (_control_status.flags.in_air && (_imu_sample_delayed.time_us - _time_last_on_ground_us) < 30000000);
+			const bool reset_yaw_to_EKFGSF = (do_reset || _do_emergency_yaw_reset) && recent_takeoff && ((_imu_sample_delayed.time_us - _emergency_yaw_reset_time) > 5000000);
 
 			if (reset_yaw_to_EKFGSF) {
 				// Attempt to recover using an alternative algorithm for estimating yaw

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -746,7 +746,6 @@ private:
 		Vector3f gyro_bias;		///< gyro bias learned and used by the quaternion calculation
 		bool quat_initialised{false};	///< true when calibrator quaternion has been aligned
 		float accel_FR[2] {};		///< front-right acceleration vector in a horizontal plane (m/s/s)
-		float yaw_rate = 0;		///< vertical component of bias compensated gyro rate (rad/s).
 		float vel_NE[2] {};		///< NE velocity vector from last GPS measurement (m/s)
 		bool fuse_gps = false;		///< true when GPS should be fused on that frame
 		float accel_dt = 0;		///< time step used when generating _simple_accel_FR data (sec)

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -265,7 +265,7 @@ public:
 	void set_min_required_gps_health_time(uint32_t time_us) { _min_gps_health_time_us = time_us; }
 
 	// get solution data for the EKF-GSF emergency yaw esitmator
-	void getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]);
+	void getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) const;
 
 	// gets data which to be logged and used for EKF-GSF development replay
 	// returns false when no data available
@@ -775,13 +775,13 @@ private:
 
 	void runEKFGSF();
 	void initialiseEKFGSF();
-	void quatPredictEKFGSF(uint8_t model_index);
+	void quatPredictEKFGSF(const uint8_t model_index);
 	void alignQuatEKFGSF();
 	void alignQuatYawEKFGSF();
-	void statePredictEKFGSF(uint8_t model_index);
-	void stateUpdateEKFGSF(uint8_t model_index);
-	float gaussianDensityEKFGSF(uint8_t model_index);
-	void makeCovSymEKFGSF(uint8_t model_index);
+	void statePredictEKFGSF(const uint8_t model_index);
+	void stateUpdateEKFGSF(const uint8_t model_index);
+	float gaussianDensityEKFGSF(const uint8_t model_index) const;
+	void makeCovSymEKFGSF(const uint8_t model_index);
 	void resetYawToEKFGSF();
 	Dcmf taitBryan312ToRotMat(Vector3f &rot312);
 };

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -406,7 +406,7 @@ public:
 	virtual void request_ekfgsf_yaw_reset(uint8_t counter) = 0;
 
 	// get ekf-gsf debug data
-	virtual void getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) = 0;
+	virtual void getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) const = 0;
 
 	// gets data which will be logged and used for algorithm development work
 	// returns false when no data avialable


### PR DESCRIPTION
- Trigger the heading reset after only one second of rejected horizontal GPS velocity measurements
- Some cleanups (See commit messages)